### PR TITLE
feat: Sinatra frontend — sortable tables + strategy class modal

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -19,9 +19,11 @@ require 'json'
 require 'redcarpet'
 
 $LOAD_PATH.unshift(File.join(__dir__, 'lib'))
+require 'cgi'
 require 'db_reader'
 require 'python_runner'
 require 'auth'
+require 'sortable_table'
 
 # ── Configuration ────────────────────────────────────────────────────────────
 
@@ -38,6 +40,7 @@ configure :development do
 end
 
 helpers AuthHelpers
+helpers SortableTable
 
 helpers do
   def db
@@ -140,7 +143,10 @@ end
 get '/strategies' do
   require_login!
   @page             = [params[:page].to_i, 1].max
-  @strategies       = db.strategies(sort:           params[:sort] || 'roi',
+  @sort_col         = params[:sort] || 'roi'
+  @sort_dir         = params[:dir]  || 'desc'
+  @strategies       = db.strategies(sort:           @sort_col,
+                                     dir:            @sort_dir,
                                      page:           @page,
                                      per_page:       50,
                                      strategy_class: params[:strategy_class].presence)
@@ -174,9 +180,7 @@ end
 get '/rota' do
   require_login!
   rota_path  = File.join(__dir__, 'ROTA.md')
-
   rota_text  = File.exist?(rota_path) ? File.read(rota_path, encoding: 'UTF-8') : '# ROTA.md not found'
-
   @rota_html = markdown(rota_text)
   erb :rota
 end
@@ -208,6 +212,66 @@ post '/api/reset' do
   require_login!
   result = runner.reset!
   json success: result[:success], error: result[:error]
+end
+
+# ── Strategy class descriptions ───────────────────────────────────────────────
+STRATEGY_CLASS_INFO = {
+  'DutchingEnvelope' => {
+    colour: '#0d6efd',
+    tagline: 'Cover multiple runners at a guaranteed return',
+    description: 'Places proportional stakes across a selection of runners so that any winner returns the same profit. Uses level, proportional, or Kelly stake models. Profitable when the sum of implied probabilities (1/odds) across the covered field is below 1.0. Best suited to races where 2–4 runners dominate the market.',
+    params: 'min_runners, max_runners, budget_pct, stake_model, min_field_prob'
+  },
+  'ExoticPermutation' => {
+    colour: '#6f42c1',
+    tagline: 'Exacta & trifecta permutation bets',
+    description: 'Generates exacta (1st + 2nd) and trifecta (1st + 2nd + 3rd) combination bets using probability-ranked selections. Applies a market-efficiency factor (~0.70) to correct theoretical exotic payouts toward realistic bookmaker returns. High variance, high ceiling.',
+    params: 'bet_type, top_n, market_efficiency, min_prob_edge'
+  },
+  'BayesianCorrelation' => {
+    colour: '#20c997',
+    tagline: 'Bayesian win-probability signals from priors',
+    description: 'Maintains Beta-distribution priors (α, β) per trainer, jockey, going, and course combination. Updates after each race: α += 1 on win, β += 1 on loss. Bets when the posterior mean exceeds a configurable confidence threshold. Requires sufficient prior data (90+ days recommended).',
+    params: 'confidence_threshold, min_evidence, hypothesis_type'
+  },
+  'OddsMovement' => {
+    colour: '#fd7e14',
+    tagline: 'Trade on significant pre-race odds drift',
+    description: 'Monitors the odds_history table for runners whose price has shortened or drifted significantly in the hours before race-off. A shortening price (steam) suggests informed money; a drifting price suggests market weakness. Bets in the direction of the movement when the change exceeds a minimum threshold.',
+    params: 'movement_threshold, hours_window, direction, min_sp'
+  },
+  'PatternRecognition' => {
+    colour: '#ffc107',
+    tagline: 'Form-cycle and rest-period pattern matching',
+    description: 'Identifies horses whose recent form sequence and days-since-last-run match historically profitable patterns. Looks for improving sequences (e.g. 3rd → 2nd → win) and optimal freshness windows. Combines multiple pattern signals into a composite score.',
+    params: 'pattern_type, days_since_run_min, days_since_run_max, min_form_score'
+  },
+  'FavouriteCover' => {
+    colour: '#dc3545',
+    tagline: 'Target short-priced course specialists',
+    description: 'Focuses on runners priced at or below a maximum SP threshold (typically ≤ 3.0) who have demonstrated course-winning form. Offers win, each-way, or dutched top-2 bet types. Highest average simulated ROI (+78%) of all strategy classes — best used in fields of 8 or fewer.',
+    params: 'max_sp, min_sp, bet_type, require_course_win'
+  },
+  'HandicapExploit' => {
+    colour: '#6c757d',
+    tagline: 'Weight sweet-spot in handicap races',
+    description: 'Targets handicap runners carrying between 5 and 15 lbs below the top weight — a range empirically associated with favourable mark relative to ability. Filters by minimum official rating and race class. Currently under recalibration (ROI –49% in sim; issue #19).',
+    params: 'weight_below_top_min, weight_below_top_max, min_rating, max_class'
+  },
+  'TrainerGoing' => {
+    colour: '#17a2b8',
+    tagline: 'Dual Bayesian signal: trainer × going × jockey',
+    description: 'Combines two Bayesian hypotheses: (1) trainer win-rate on a specific going type, and (2) trainer–jockey partnership win-rate. The require_both flag controls whether both signals must fire (AND) or either is sufficient (OR). Needs 90+ days of data to build reliable posteriors.',
+    params: 'min_confidence, require_both, min_evidence'
+  }
+}.freeze
+
+# JSON endpoint — strategy class info for modal display
+get '/api/strategy_class/:name' do
+  require_login!
+  info = STRATEGY_CLASS_INFO[params[:name]]
+  halt 404, json(error: 'Unknown class') unless info
+  json({ name: params[:name] }.merge(info))
 end
 
 # ── Health / API ──────────────────────────────────────────────────────────────

--- a/lib/db_reader.rb
+++ b/lib/db_reader.rb
@@ -1,0 +1,339 @@
+# lib/db_reader.rb
+# Read-only access to the Python simulation SQLite database.
+# Sinatra reads directly — no Python subprocess needed for queries.
+
+require 'sqlite3'
+require 'json'
+
+class DBReader
+  DEFAULT_DB = File.expand_path('../../py/data/horse_racing.db', __FILE__)
+
+  def initialize(db_path = DEFAULT_DB)
+    @db_path = db_path
+  end
+
+  def connected?
+    File.exist?(@db_path)
+  end
+
+  # ── Races ──────────────────────────────────────────────────────────────────
+
+  def races(page: 1, per_page: 30, race_type: nil, sim_day: nil)
+    where = []
+    params = []
+    where << 'r.race_type = ?' and params << race_type if race_type
+    where << 'r.sim_day = ?'  and params << sim_day    if sim_day
+    cond = where.empty? ? '' : "WHERE #{where.join(' AND ')}"
+    offset = (page - 1) * per_page
+    query(<<~SQL, *params, per_page, offset)
+      SELECT r.*, v.name AS venue_name, v.country
+      FROM races r JOIN venues v ON r.venue_id = v.id
+      #{cond}
+      ORDER BY r.sim_day DESC, r.race_time ASC
+      LIMIT ? OFFSET ?
+    SQL
+  end
+
+  def race(id)
+    query_one('SELECT r.*, v.name AS venue_name, v.country FROM races r JOIN venues v ON r.venue_id = v.id WHERE r.id = ?', id)
+  end
+
+  def race_runners(race_id)
+    query(<<~SQL, race_id)
+      SELECT ru.*, h.name AS horse_name, h.trainer, h.sire,
+             rr.position, rr.btn_lengths
+      FROM runners ru
+      JOIN horses h ON ru.horse_id = h.id
+      LEFT JOIN race_results rr ON rr.runner_id = ru.id
+      WHERE ru.race_id = ?
+      ORDER BY COALESCE(rr.position, 99), ru.favourite_rank
+    SQL
+  end
+
+  def race_odds_history(race_id)
+    query(<<~SQL, race_id)
+      SELECT oh.*, ru.cloth_number, h.name AS horse_name
+      FROM odds_history oh
+      JOIN runners ru ON oh.runner_id = ru.id
+      JOIN horses h ON ru.horse_id = h.id
+      WHERE oh.race_id = ?
+      ORDER BY ru.cloth_number, oh.hours_before DESC
+    SQL
+  end
+
+  def races_count
+    query_one('SELECT COUNT(*) AS n FROM races')[:n]
+  end
+
+  # ── Horses ─────────────────────────────────────────────────────────────────
+
+  def horses(page: 1, per_page: 40, search: nil)
+    params = []
+    cond = ''
+    if search && !search.empty?
+      cond = "WHERE h.name LIKE ?"
+      params << "%#{search}%"
+    end
+    offset = (page - 1) * per_page
+    query(<<~SQL, *params, per_page, offset)
+      SELECT h.*,
+             COUNT(DISTINCT ru.id) AS total_runs,
+             SUM(CASE WHEN rr.position = 1 THEN 1 ELSE 0 END) AS total_wins
+      FROM horses h
+      LEFT JOIN runners ru ON ru.horse_id = h.id
+      LEFT JOIN race_results rr ON rr.runner_id = ru.id
+      #{cond}
+      GROUP BY h.id
+      ORDER BY total_wins DESC, h.name ASC
+      LIMIT ? OFFSET ?
+    SQL
+  end
+
+  def horse(id)
+    query_one(<<~SQL, id)
+      SELECT h.*,
+             COUNT(DISTINCT ru.id) AS total_runs,
+             SUM(CASE WHEN rr.position = 1 THEN 1 ELSE 0 END) AS total_wins
+      FROM horses h
+      LEFT JOIN runners ru ON ru.horse_id = h.id
+      LEFT JOIN race_results rr ON rr.runner_id = ru.id
+      WHERE h.id = ?
+      GROUP BY h.id
+    SQL
+  end
+
+  def horse_recent_runs(horse_id, limit: 10)
+    query(<<~SQL, horse_id, limit)
+      SELECT r.race_date, r.race_time, r.race_type, r.going, r.distance_furlongs,
+             v.name AS venue_name, ru.sp, ru.weight_lbs, ru.jockey,
+             rr.position, rr.btn_lengths
+      FROM runners ru
+      JOIN races r ON ru.race_id = r.id
+      JOIN venues v ON r.venue_id = v.id
+      LEFT JOIN race_results rr ON rr.runner_id = ru.id
+      WHERE ru.horse_id = ?
+      ORDER BY r.race_date DESC, r.race_time DESC
+      LIMIT ?
+    SQL
+  end
+
+  def horse_h2h(horse_id)
+    query(<<~SQL, horse_id, horse_id)
+      SELECT ha.name AS horse_a, hb.name AS horse_b,
+             hr.meetings, hr.horse_a_ahead, hr.horse_b_ahead
+      FROM horse_relationships hr
+      JOIN horses ha ON hr.horse_a_id = ha.id
+      JOIN horses hb ON hr.horse_b_id = hb.id
+      WHERE hr.horse_a_id = ? OR hr.horse_b_id = ?
+      ORDER BY hr.meetings DESC
+      LIMIT 20
+    SQL
+  end
+
+  # ── Venues ─────────────────────────────────────────────────────────────────
+
+  def venues
+    query(<<~SQL)
+      SELECT v.*,
+             COUNT(DISTINCT r.id) AS race_count,
+             AVG(r.runner_count) AS avg_field_size
+      FROM venues v
+      LEFT JOIN races r ON r.venue_id = v.id
+      GROUP BY v.id
+      ORDER BY race_count DESC
+    SQL
+  end
+
+  # ── Strategies ─────────────────────────────────────────────────────────────
+
+  def strategies(sort: 'roi', dir: nil, page: 1, per_page: 50, strategy_class: nil)
+    valid_sorts = %w[roi profit_loss total_bets wins strike_rate sharpe max_drawdown]
+    sort = 'roi' unless valid_sorts.include?(sort)
+    # Allow caller to override direction; default is DESC for most metrics,
+    # ASC for drawdown (lower is better).
+    default_dir = sort == 'max_drawdown' ? 'ASC' : 'DESC'
+    direction   = %w[asc desc].include?(dir.to_s.downcase) ? dir.upcase : default_dir
+
+    cond = strategy_class ? 'WHERE s.strategy_class = ?' : ''
+    params = strategy_class ? [strategy_class] : []
+    offset = (page - 1) * per_page
+
+    query(<<~SQL, *params, per_page, offset)
+      SELECT sp.*, s.strategy_class, s.variant_name, s.params_json
+      FROM strategy_performance sp
+      JOIN strategies s ON sp.strategy_id = s.id
+      WHERE sp.sim_day = (
+        SELECT MAX(sim_day) FROM strategy_performance sp2
+        WHERE sp2.strategy_id = sp.strategy_id
+      )
+      #{cond.empty? ? '' : "AND s.strategy_class = ?"}
+      ORDER BY sp.#{sort} #{direction} NULLS LAST
+      LIMIT ? OFFSET ?
+    SQL
+  end
+
+  def strategy(id)
+    query_one(<<~SQL, id)
+      SELECT sp.*, s.strategy_class, s.variant_name, s.params_json, s.created_at
+      FROM strategy_performance sp
+      JOIN strategies s ON sp.strategy_id = s.id
+      WHERE sp.strategy_id = ?
+      ORDER BY sp.sim_day DESC LIMIT 1
+    SQL
+  end
+
+  def strategy_daily_pl(strategy_id)
+    query(<<~SQL, strategy_id)
+      SELECT r.sim_day,
+             SUM(b.stake) AS staked,
+             SUM(COALESCE(b.payout, 0)) AS returned,
+             SUM(COALESCE(b.payout, 0)) - SUM(b.stake) AS pl,
+             COUNT(*) AS bets,
+             SUM(CASE WHEN b.status = 'won' THEN 1 ELSE 0 END) AS wins
+      FROM bets b JOIN races r ON b.race_id = r.id
+      WHERE b.strategy_id = ? AND b.status != 'pending'
+      GROUP BY r.sim_day ORDER BY r.sim_day
+    SQL
+  end
+
+  def strategy_recent_bets(strategy_id, limit: 20)
+    query(<<~SQL, strategy_id, limit)
+      SELECT b.*, r.race_date, r.race_type, r.going,
+             v.name AS venue_name, s.variant_name
+      FROM bets b
+      JOIN races r ON b.race_id = r.id
+      JOIN venues v ON r.venue_id = v.id
+      JOIN strategies s ON b.strategy_id = s.id
+      WHERE b.strategy_id = ? AND b.status != 'pending'
+      ORDER BY r.sim_day DESC, r.race_time DESC
+      LIMIT ?
+    SQL
+  end
+
+  def strategy_classes
+    query('SELECT strategy_class, COUNT(*) AS n FROM strategies GROUP BY strategy_class ORDER BY n DESC')
+  end
+
+  # ── Performance Summary ────────────────────────────────────────────────────
+
+  def performance_summary
+    query_one(<<~SQL)
+      SELECT
+        COUNT(DISTINCT s.id) AS total_strategies,
+        COUNT(b.id) AS total_bets,
+        SUM(b.stake) AS total_staked,
+        SUM(COALESCE(b.payout, 0)) AS total_returned,
+        SUM(COALESCE(b.payout, 0)) - SUM(b.stake) AS total_pl,
+        SUM(CASE WHEN b.status = 'won' THEN 1 ELSE 0 END) AS total_wins,
+        MAX(r.sim_day) AS max_day
+      FROM bets b
+      JOIN races r ON b.race_id = r.id
+      JOIN strategies s ON b.strategy_id = s.id
+      WHERE b.status != 'pending'
+    SQL
+  end
+
+  def daily_pl_series
+    query(<<~SQL)
+      SELECT r.sim_day, r.race_date,
+             SUM(b.stake) AS staked,
+             SUM(COALESCE(b.payout, 0)) AS returned,
+             SUM(COALESCE(b.payout, 0)) - SUM(b.stake) AS pl,
+             COUNT(*) AS bets
+      FROM bets b JOIN races r ON b.race_id = r.id
+      WHERE b.status != 'pending'
+      GROUP BY r.sim_day ORDER BY r.sim_day
+    SQL
+  end
+
+  def top_strategies(n: 5)
+    query(<<~SQL, n)
+      SELECT sp.roi, sp.profit_loss, sp.total_bets, sp.wins,
+             s.strategy_class, s.variant_name
+      FROM strategy_performance sp
+      JOIN strategies s ON sp.strategy_id = s.id
+      WHERE sp.sim_day = (SELECT MAX(sim_day) FROM strategy_performance sp2 WHERE sp2.strategy_id = sp.strategy_id)
+        AND sp.total_bets >= 10
+      ORDER BY sp.roi DESC NULLS LAST
+      LIMIT ?
+    SQL
+  end
+
+  # ── Bayesian / Correlations ────────────────────────────────────────────────
+
+  def hypothesis(type: nil, min_evidence: 3, limit: 50)
+    cond = type ? "AND hypothesis_type = '#{type.gsub("'", '')}'" : ''
+    query(<<~SQL, min_evidence, limit)
+      SELECT * FROM hypothesis
+      WHERE evidence_count >= ? #{cond}
+      ORDER BY confidence DESC
+      LIMIT ?
+    SQL
+  end
+
+  def beta_horses(min_meetings: 3)
+    query(<<~SQL, min_meetings)
+      SELECT hr.meetings, hr.horse_a_ahead, hr.horse_b_ahead,
+             ha.name AS horse_a, hb.name AS horse_b,
+             ROUND(hr.horse_a_ahead * 1.0 / hr.meetings, 3) AS dominance
+      FROM horse_relationships hr
+      JOIN horses ha ON hr.horse_a_id = ha.id
+      JOIN horses hb ON hr.horse_b_id = hb.id
+      WHERE hr.meetings >= ?
+        AND (hr.horse_a_ahead * 1.0 / hr.meetings >= 0.8
+             OR hr.horse_b_ahead * 1.0 / hr.meetings >= 0.8)
+      ORDER BY dominance DESC
+      LIMIT 30
+    SQL
+  end
+
+  def top_trainer_jockey(limit: 20)
+    query(<<~SQL, limit)
+      SELECT trainer, jockey, wins, runs, win_rate
+      FROM trainer_jockey_stats
+      WHERE runs >= 5
+      ORDER BY win_rate DESC, runs DESC
+      LIMIT ?
+    SQL
+  end
+
+  # ── Simulation metadata ────────────────────────────────────────────────────
+
+  def sim_days
+    query_one('SELECT MIN(sim_day) AS first_day, MAX(sim_day) AS last_day, COUNT(DISTINCT sim_day) AS total_days FROM races')
+  end
+
+  def bankroll_history(strategy_id)
+    query('SELECT * FROM bankroll_snapshots WHERE strategy_id = ? ORDER BY sim_day', strategy_id)
+  end
+
+  private
+
+  def db
+    @db ||= begin
+      raise "Database not found: #{@db_path}" unless File.exist?(@db_path)
+      conn = SQLite3::Database.new(@db_path, readonly: true)
+      conn.results_as_hash = true
+      conn
+    end
+  end
+
+  def query(sql, *params)
+    db.execute(sql, params).map { |row| symbolize(row) }
+  rescue SQLite3::Exception => e
+    warn "DBReader query error: #{e.message}"
+    []
+  end
+
+  def query_one(sql, *params)
+    row = db.get_first_row(sql, params)
+    row ? symbolize(row) : nil
+  rescue SQLite3::Exception => e
+    warn "DBReader query_one error: #{e.message}"
+    nil
+  end
+
+  def symbolize(hash)
+    hash.transform_keys { |k| k.to_sym rescue k }
+  end
+end

--- a/lib/sortable_table.rb
+++ b/lib/sortable_table.rb
@@ -1,0 +1,67 @@
+# lib/sortable_table.rb
+# Sinatra helper for server-side sortable column headers.
+#
+# Usage in ERB (server-side sort with full-page reload):
+#   <%= sort_th('ROI%', 'roi', sort_col: params[:sort], sort_dir: params[:dir],
+#               base_url: '/strategies', extra_params: {strategy_class: params[:strategy_class]}) %>
+#
+# Hierarchy (as per issue #25):
+#   SortableTable  (this module)
+#     └─ included as a helper → all ERB templates get sort_th
+#
+# For client-side in-page sort, mark any <table> with class="sortable-table"
+# and add data-col="N" to each <th>. app.js picks this up automatically.
+
+module SortableTable
+  # SVG icons — line (neutral), up arrow (asc), down arrow (desc)
+  SVG_NONE = '<svg class="sort-icon" width="9" height="12" viewBox="0 0 9 12" ' \
+             'fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">' \
+             '<line x1="4.5" y1="2" x2="4.5" y2="10"/>' \
+             '</svg>'.freeze
+
+  SVG_ASC  = '<svg class="sort-icon" width="9" height="12" viewBox="0 0 9 12" ' \
+             'fill="none" stroke="currentColor" stroke-width="1.5" ' \
+             'stroke-linecap="round" stroke-linejoin="round">' \
+             '<polyline points="1.5,7 4.5,2 7.5,7"/>' \
+             '<line x1="4.5" y1="2" x2="4.5" y2="11"/>' \
+             '</svg>'.freeze
+
+  SVG_DESC = '<svg class="sort-icon" width="9" height="12" viewBox="0 0 9 12" ' \
+             'fill="none" stroke="currentColor" stroke-width="1.5" ' \
+             'stroke-linecap="round" stroke-linejoin="round">' \
+             '<polyline points="1.5,5 4.5,10 7.5,5"/>' \
+             '<line x1="4.5" y1="1" x2="4.5" y2="10"/>' \
+             '</svg>'.freeze
+
+  # Render a sortable <th> with a linked label and SVG direction indicator.
+  #
+  # @param label       [String]  Column display name
+  # @param col         [String]  Sort key passed as ?sort=col
+  # @param sort_col    [String]  Currently active sort column (from params)
+  # @param sort_dir    [String]  Current direction 'asc'|'desc' (from params, default 'desc')
+  # @param base_url    [String]  Route path, e.g. '/strategies'
+  # @param extra_params[Hash]   Additional query params to preserve (e.g. filters)
+  # @param css         [String]  Extra CSS classes for the <th>
+  def sort_th(label, col, sort_col:, base_url:, sort_dir: 'desc', extra_params: {}, css: '')
+    col      = col.to_s
+    sort_col = sort_col.to_s
+    active   = sort_col == col
+
+    # Toggle direction when clicking the active column; default to desc otherwise
+    new_dir = (active && sort_dir == 'desc') ? 'asc' : 'desc'
+    icon    = active ? (sort_dir == 'asc' ? SVG_ASC : SVG_DESC) : SVG_NONE
+
+    qs = extra_params
+           .reject { |_, v| v.nil? || v.to_s.empty? }
+           .merge(sort: col, dir: new_dir)
+           .map { |k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }
+           .join('&')
+
+    active_css = active ? ' sort-active' : ''
+    <<~HTML.strip
+      <th class="sortable-col#{active_css} #{css}" style="white-space:nowrap">
+        <a href="#{base_url}?#{qs}" class="text-decoration-none text-white d-inline-flex align-items-center gap-1">#{label}#{icon}</a>
+      </th>
+    HTML
+  end
+end

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,82 @@
+// app.js — Horse Racing front-end helpers
+
+// ── SortableTable ─────────────────────────────────────────────────────────────
+// Client-side in-page sort for tables marked with class="sortable-table".
+// Add data-col="N" (0-indexed) to each <th> you want to be sortable.
+// Numeric cells are sorted numerically; everything else lexicographically.
+// SVG icons: line (unsorted) / up-arrow (asc) / down-arrow (desc).
+(function () {
+  var SVG = {
+    none: '<svg class="sort-icon" width="9" height="12" viewBox="0 0 9 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="4.5" y1="2" x2="4.5" y2="10"/></svg>',
+    asc:  '<svg class="sort-icon" width="9" height="12" viewBox="0 0 9 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="1.5,7 4.5,2 7.5,7"/><line x1="4.5" y1="2" x2="4.5" y2="11"/></svg>',
+    desc: '<svg class="sort-icon" width="9" height="12" viewBox="0 0 9 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="1.5,5 4.5,10 7.5,5"/><line x1="4.5" y1="1" x2="4.5" y2="10"/></svg>'
+  };
+
+  function cellVal(row, col) {
+    var td = row.querySelectorAll('td')[col];
+    return td ? (td.dataset.sortVal || td.innerText.trim()) : '';
+  }
+
+  function sortTable(table, col, dir) {
+    var tbody = table.querySelector('tbody');
+    var rows  = Array.from(tbody.querySelectorAll('tr'));
+    var num   = rows.every(function (r) { return !isNaN(parseFloat(cellVal(r, col))); });
+
+    rows.sort(function (a, b) {
+      var av = cellVal(a, col), bv = cellVal(b, col);
+      var cmp = num ? (parseFloat(av) - parseFloat(bv)) : av.localeCompare(bv);
+      return dir === 'asc' ? cmp : -cmp;
+    });
+    rows.forEach(function (r) { tbody.appendChild(r); });
+  }
+
+  function updateIcons(table, activeCol, dir) {
+    table.querySelectorAll('th[data-col]').forEach(function (th) {
+      var label = th.dataset.label || th.innerText.replace(/[\u2190-\u21FF]/g, '').trim();
+      th.dataset.label = label;
+      var icon  = parseInt(th.dataset.col) === activeCol ? SVG[dir] : SVG.none;
+      th.innerHTML = label + icon;
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('table.sortable-table').forEach(function (table) {
+      table._sortCol = -1;
+      table._sortDir = 'asc';
+
+      table.querySelectorAll('th[data-col]').forEach(function (th) {
+        th.style.cursor = 'pointer';
+        th.style.userSelect = 'none';
+        th.style.whiteSpace = 'nowrap';
+        th.innerHTML = (th.dataset.label || th.innerText.trim()) + SVG.none;
+        th.dataset.label = th.dataset.label || th.innerText.replace(/<[^>]+>/g, '').trim();
+
+        th.addEventListener('click', function () {
+          var col = parseInt(th.dataset.col);
+          var dir = (table._sortCol === col && table._sortDir === 'desc') ? 'asc' : 'desc';
+          table._sortCol = col;
+          table._sortDir = dir;
+          sortTable(table, col, dir);
+          updateIcons(table, col, dir);
+        });
+      });
+    });
+  });
+}());
+
+// ── General helpers ───────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', function () {
+  // Auto-dismiss alerts after 5 s
+  document.querySelectorAll('.alert-dismissible').forEach(function (el) {
+    setTimeout(function () {
+      var bsAlert = bootstrap.Alert.getOrCreateInstance(el);
+      bsAlert && bsAlert.close();
+    }, 5000);
+  });
+
+  // Colour elements with data-pl attribute
+  document.querySelectorAll('[data-pl]').forEach(function (el) {
+    var v = parseFloat(el.dataset.pl);
+    el.classList.add(v >= 0 ? 'text-success' : 'text-danger');
+  });
+});

--- a/views/horses.erb
+++ b/views/horses.erb
@@ -1,0 +1,67 @@
+<% @title = 'Horses' %>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="fw-bold mb-0"><i class="bi bi-heart-pulse text-warning me-2"></i>Horses</h2>
+</div>
+
+<form method="GET" action="/horses" class="row g-2 mb-4">
+  <div class="col-auto">
+    <input type="text" name="search" class="form-control form-control-sm bg-dark text-white border-secondary"
+           placeholder="Search by name…" value="<%= params[:search] %>">
+  </div>
+  <div class="col-auto">
+    <button class="btn btn-sm btn-outline-warning" type="submit"><i class="bi bi-search me-1"></i>Search</button>
+    <a href="/horses" class="btn btn-sm btn-outline-secondary">Clear</a>
+  </div>
+</form>
+
+<div class="table-responsive">
+  <table class="table table-dark table-hover table-sm sortable-table">
+    <thead>
+      <tr>
+        <th data-col="0">Horse</th><th data-col="1">Trainer</th><th data-col="2">Sire</th>
+        <th data-col="3" class="text-end">Runs</th><th data-col="4" class="text-end">Wins</th>
+        <th data-col="5" class="text-end">Win%</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @horses.each do |h| %>
+        <tr>
+          <td><a href="/horses/<%= h[:id] %>" class="text-decoration-none fw-semibold"><%= h[:name] %></a></td>
+          <td class="text-muted small"><%= h[:trainer] %></td>
+          <td class="text-muted small"><%= h[:sire] %></td>
+          <td class="text-end"><%= h[:total_runs] %></td>
+          <td class="text-end"><%= h[:total_wins] %></td>
+          <td class="text-end">
+            <% wr = h[:total_runs].to_f > 0 ? (h[:total_wins].to_f / h[:total_runs].to_f * 100) : 0 %>
+            <span class="<%= wr >= 30 ? 'text-success fw-bold' : wr >= 15 ? 'text-warning' : 'text-muted' %>">
+              <%= "%.0f" % wr %>%
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<nav>
+  <ul class="pagination pagination-sm justify-content-center">
+    <% if @page > 1 %>
+      <li class="page-item">
+        <a class="page-link bg-dark border-secondary" href="/horses?page=<%= @page - 1 %>&search=<%= params[:search] %>">
+          &laquo; Prev
+        </a>
+      </li>
+    <% end %>
+    <li class="page-item disabled">
+      <span class="page-link bg-dark border-secondary">Page <%= @page %></span>
+    </li>
+    <% if @horses.length >= 40 %>
+      <li class="page-item">
+        <a class="page-link bg-dark border-secondary" href="/horses?page=<%= @page + 1 %>&search=<%= params[:search] %>">
+          Next &raquo;
+        </a>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/views/races.erb
+++ b/views/races.erb
@@ -1,0 +1,74 @@
+<% @title = 'Races' %>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="fw-bold mb-0"><i class="bi bi-flag text-warning me-2"></i>Races</h2>
+  <span class="text-muted"><%= @total %> total</span>
+</div>
+
+<!-- Filters -->
+<form method="GET" action="/races" class="row g-2 mb-4">
+  <div class="col-auto">
+    <select name="race_type" class="form-select form-select-sm bg-dark text-white border-secondary">
+      <option value="">All types</option>
+      <option value="flat"   <%= 'selected' if params[:race_type] == 'flat' %>>Flat</option>
+      <option value="nh"     <%= 'selected' if params[:race_type] == 'nh' %>>NH</option>
+    </select>
+  </div>
+  <div class="col-auto">
+    <input type="number" name="sim_day" class="form-control form-control-sm bg-dark text-white border-secondary"
+           placeholder="Day" value="<%= params[:sim_day] %>" min="1" style="width:80px">
+  </div>
+  <div class="col-auto">
+    <button class="btn btn-sm btn-outline-warning" type="submit">Filter</button>
+    <a href="/races" class="btn btn-sm btn-outline-secondary">Clear</a>
+  </div>
+</form>
+
+<div class="table-responsive">
+  <table class="table table-dark table-hover table-sm sortable-table">
+    <thead class="table-dark">
+      <tr>
+        <th data-col="0">Day</th><th data-col="1">Date</th><th data-col="2">Time</th><th data-col="3">Venue</th>
+        <th data-col="4">Type</th><th data-col="5">Going</th><th data-col="6">Dist (f)</th><th data-col="7">Runners</th><th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @races.each do |r| %>
+        <tr>
+          <td><span class="badge bg-secondary"><%= r[:sim_day] %></span></td>
+          <td><%= r[:race_date] %></td>
+          <td><%= r[:race_time] %></td>
+          <td><%= r[:venue_name] %> <small class="text-muted">(<%= r[:country] %>)</small></td>
+          <td><span class="badge <%= r[:race_type] == 'flat' ? 'bg-info' : 'bg-warning text-dark' %>"><%= r[:race_type] %></span></td>
+          <td><%= r[:going] %></td>
+          <td><%= r[:distance_furlongs] %></td>
+          <td><%= r[:runner_count] %></td>
+          <td><a href="/races/<%= r[:id] %>" class="btn btn-xs btn-outline-secondary btn-sm py-0">View</a></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<!-- Pagination -->
+<nav>
+  <ul class="pagination pagination-sm justify-content-center">
+    <% if @page > 1 %>
+      <li class="page-item">
+        <a class="page-link bg-dark border-secondary" href="/races?page=<%= @page - 1 %>&race_type=<%= params[:race_type] %>&sim_day=<%= params[:sim_day] %>">
+          &laquo; Prev
+        </a>
+      </li>
+    <% end %>
+    <li class="page-item disabled">
+      <span class="page-link bg-dark border-secondary">Page <%= @page %></span>
+    </li>
+    <% if @races.length >= 30 %>
+      <li class="page-item">
+        <a class="page-link bg-dark border-secondary" href="/races?page=<%= @page + 1 %>&race_type=<%= params[:race_type] %>&sim_day=<%= params[:sim_day] %>">
+          Next &raquo;
+        </a>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/views/strategies.erb
+++ b/views/strategies.erb
@@ -1,0 +1,176 @@
+<% @title = 'Strategies' %>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="fw-bold mb-0"><i class="bi bi-bar-chart-line text-warning me-2"></i>Strategies</h2>
+</div>
+
+<!-- Filter/Sort -->
+<form method="GET" action="/strategies" class="row g-2 mb-4">
+  <div class="col-auto">
+    <select name="strategy_class" class="form-select form-select-sm bg-dark text-white border-secondary">
+      <option value="">All classes</option>
+      <% @strategy_classes.each do |sc| %>
+        <option value="<%= sc[:strategy_class] %>" <%= 'selected' if params[:strategy_class] == sc[:strategy_class] %>>
+          <%= sc[:strategy_class] %> (<%= sc[:n] %>)
+        </option>
+      <% end %>
+    </select>
+  </div>
+  <div class="col-auto">
+    <select name="sort" class="form-select form-select-sm bg-dark text-white border-secondary">
+      <% %w[roi profit_loss total_bets wins strike_rate sharpe max_drawdown].each do |s| %>
+        <option value="<%= s %>" <%= 'selected' if (params[:sort] || 'roi') == s %>><%= s.tr('_',' ').capitalize %></option>
+      <% end %>
+    </select>
+  </div>
+  <div class="col-auto">
+    <button class="btn btn-sm btn-outline-warning" type="submit">Sort / Filter</button>
+    <a href="/strategies" class="btn btn-sm btn-outline-secondary">Reset</a>
+  </div>
+</form>
+
+<div class="table-responsive">
+  <table class="table table-dark table-hover table-sm">
+    <thead>
+      <tr>
+        <th>Class</th><th>Variant</th>
+        <%
+          _ep = { strategy_class: params[:strategy_class], page: @page }
+          _u  = '/strategies'
+          _sc = @sort_col
+          _sd = @sort_dir
+        %>
+        <%= sort_th('ROI%',   'roi',          sort_col: _sc, sort_dir: _sd, base_url: _u, extra_params: _ep, css: 'text-end') %>
+        <%= sort_th('P&L',    'profit_loss',  sort_col: _sc, sort_dir: _sd, base_url: _u, extra_params: _ep, css: 'text-end') %>
+        <%= sort_th('Bets',   'total_bets',   sort_col: _sc, sort_dir: _sd, base_url: _u, extra_params: _ep, css: 'text-end') %>
+        <%= sort_th('Wins',   'wins',         sort_col: _sc, sort_dir: _sd, base_url: _u, extra_params: _ep, css: 'text-end') %>
+        <%= sort_th('SR%',    'strike_rate',  sort_col: _sc, sort_dir: _sd, base_url: _u, extra_params: _ep, css: 'text-end') %>
+        <%= sort_th('Sharpe', 'sharpe',       sort_col: _sc, sort_dir: _sd, base_url: _u, extra_params: _ep, css: 'text-end') %>
+        <%= sort_th('DD%',    'max_drawdown', sort_col: _sc, sort_dir: _sd, base_url: _u, extra_params: _ep, css: 'text-end') %>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @strategies.each do |s| %>
+        <tr>
+          <td>
+            <span class="badge bg-secondary small strategy-class-pill"
+                  data-class="<%= s[:strategy_class] %>"
+                  role="button" tabindex="0"
+                  title="Click to view class details"
+                  style="cursor:pointer">
+              <i class="bi bi-info-circle me-1" style="font-size:0.7rem"></i><%= s[:strategy_class] %>
+            </span>
+          </td>
+          <td class="small"><%= s[:variant_name] %></td>
+          <td class="text-end fw-bold <%= s[:roi].to_f >= 0 ? 'text-success' : 'text-danger' %>">
+            <%= "%.1f" % s[:roi].to_f %>
+          </td>
+          <td class="text-end small <%= s[:profit_loss].to_f >= 0 ? 'text-success' : 'text-danger' %>">
+            £<%= "%.2f" % s[:profit_loss].to_f %>
+          </td>
+          <td class="text-end small"><%= s[:total_bets] %></td>
+          <td class="text-end small"><%= s[:wins] %></td>
+          <td class="text-end small">
+            <% sr = s[:total_bets].to_f > 0 ? (s[:wins].to_f / s[:total_bets].to_f * 100) : 0 %>
+            <%= "%.1f" % sr %>
+          </td>
+          <td class="text-end small <%= s[:sharpe].to_f >= 1 ? 'text-success' : s[:sharpe].to_f >= 0 ? '' : 'text-danger' %>">
+            <%= s[:sharpe] ? "%.2f" % s[:sharpe].to_f : '—' %>
+          </td>
+          <td class="text-end small text-warning">
+            <%= s[:max_drawdown] ? "%.1f" % s[:max_drawdown].to_f : '—' %>
+          </td>
+          <td><a href="/strategies/<%= s[:strategy_id] %>" class="btn btn-sm btn-outline-secondary py-0">View</a></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<nav>
+  <ul class="pagination pagination-sm justify-content-center">
+    <% if @page > 1 %>
+      <li class="page-item">
+        <a class="page-link bg-dark border-secondary"
+           href="/strategies?page=<%= @page-1 %>&sort=<%= params[:sort] %>&strategy_class=<%= params[:strategy_class] %>">
+          &laquo; Prev
+        </a>
+      </li>
+    <% end %>
+    <li class="page-item disabled">
+      <span class="page-link bg-dark border-secondary">Page <%= @page %></span>
+    </li>
+    <% if @strategies.length >= 50 %>
+      <li class="page-item">
+        <a class="page-link bg-dark border-secondary"
+           href="/strategies?page=<%= @page+1 %>&sort=<%= params[:sort] %>&strategy_class=<%= params[:strategy_class] %>">
+          Next &raquo;
+        </a>
+      </li>
+    <% end %>
+  </ul>
+</nav>
+
+<!-- Strategy Class Info Modal -->
+<div class="modal fade" id="classInfoModal" tabindex="-1" aria-labelledby="classInfoModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content bg-dark border-secondary text-white">
+      <div class="modal-header border-secondary">
+        <h5 class="modal-title" id="classInfoModalLabel">
+          <span id="modal-class-name" class="badge me-2" style="font-size:1rem"></span>
+          Strategy Class
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="text-muted fst-italic mb-3" id="modal-tagline"></p>
+        <p id="modal-description"></p>
+        <div class="mt-3">
+          <h6 class="text-warning">Parameters</h6>
+          <code id="modal-params" class="text-info"></code>
+        </div>
+      </div>
+      <div class="modal-footer border-secondary">
+        <a id="modal-filter-link" href="#" class="btn btn-sm btn-outline-warning">
+          Filter strategies to this class
+        </a>
+        <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var cache = {};
+
+  function showModal(className) {
+    if (cache[className]) return populate(className, cache[className]);
+    fetch('/api/strategy_class/' + encodeURIComponent(className))
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (data) { cache[className] = data; populate(className, data); })
+      .catch(function () { populate(className, { tagline: '(no description available)', description: '', params: '', colour: '#6c757d' }); });
+  }
+
+  function populate(className, data) {
+    document.getElementById('modal-class-name').textContent = className;
+    document.getElementById('modal-class-name').style.background = data.colour || '#6c757d';
+    document.getElementById('modal-tagline').textContent     = data.tagline || '';
+    document.getElementById('modal-description').textContent = data.description || '';
+    document.getElementById('modal-params').textContent      = data.params || '';
+    document.getElementById('modal-filter-link').href        = '/strategies?strategy_class=' + encodeURIComponent(className);
+    new bootstrap.Modal(document.getElementById('classInfoModal')).show();
+  }
+
+  document.addEventListener('click', function (e) {
+    var pill = e.target.closest('.strategy-class-pill');
+    if (pill) { e.preventDefault(); showModal(pill.dataset.class); }
+  });
+  document.addEventListener('keydown', function (e) {
+    if ((e.key === 'Enter' || e.key === ' ') && e.target.classList.contains('strategy-class-pill')) {
+      e.preventDefault(); showModal(e.target.dataset.class);
+    }
+  });
+}());
+</script>


### PR DESCRIPTION
Replaces PRs #31 and #32 — single clean branch on top of current master (which already contains #24, #29, #30).

## Changes

**Sortable columns (closes #25)**
- `lib/sortable_table.rb` — `sort_th()` helper: `<th>` with sort link + SVG icon (line / ↑ / ↓)
- `lib/db_reader.rb` — `strategies()` gains `dir:` param
- `app.rb` — `require`/`helpers SortableTable`, `@sort_col`/`@sort_dir` in `/strategies` route
- `views/strategies.erb` — server-side sort headers via `sort_th()`
- `views/races.erb`, `views/horses.erb` — `sortable-table` class + `data-col` for client-side sort
- `public/js/app.js` — `SortableTable` IIFE; click to sort, SVG arrows update live

**Strategy class modal (closes #26)**
- `app.rb` — `STRATEGY_CLASS_INFO` constant + `GET /api/strategy_class/:name`
- `views/strategies.erb` — class pills clickable → Bootstrap modal (description, params, filter link)

## Test plan
- [ ] `/strategies` — click column headers, direction toggles, arrow updates
- [ ] Sort links preserve active class filter
- [ ] `/races`, `/horses` — client-side sort, no page reload
- [ ] Click class pill → modal with correct content
- [ ] `GET /api/strategy_class/Nonexistent` → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)