### PR TITLE
fix: top_strategies missing strategy_id — dashboard links 404

### DIFF
--- a/lib/db_reader.rb
+++ b/lib/db_reader.rb
@@ -248,7 +248,7 @@ class DBReader
 
   def top_strategies(n: 5)
     query(<<~SQL, n)
-      SELECT sp.roi, sp.profit_loss, sp.total_bets, sp.wins,
+      SELECT s.id AS strategy_id, sp.roi, sp.profit_loss, sp.total_bets, sp.wins,
              s.strategy_class, s.variant_name
       FROM strategy_performance sp
       JOIN strategies s ON sp.strategy_id = s.id

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -83,7 +83,7 @@
             <li class="list-group-item bg-dark border-secondary d-flex justify-content-between align-items-start">
               <div>
                 <span class="badge bg-warning text-dark me-1">#<%= i+1 %></span>
-                <a href="/strategies/<%= s[:strategy_id] rescue '#' %>" class="text-decoration-none">
+                <a href="/strategies/<%= s[:strategy_id] %>" class="text-decoration-none">
                   <%= s[:variant_name] %>
                 </a>
                 <br><small class="text-muted"><%= s[:strategy_class] %></small>


### PR DESCRIPTION
## Root cause

`db_reader.rb#top_strategies` selected `roi, profit_loss, total_bets, wins, strategy_class, variant_name` but never included `s.id`. The dashboard template referenced `s[:strategy_id]` which was always `nil`, producing links to `/strategies/` → 404.

## Fix

- Added `s.id AS strategy_id` to the `top_strategies` SELECT list
- Removed `rescue '#'` from `dashboard.erb` — it was silently masking the nil instead of surfacing it

## Test plan

- [ ] Dashboard Top Strategies panel — each item links correctly to `/strategies/:id`
- [ ] No 404 on click-through

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)